### PR TITLE
Add support for MCP3304, 13-bit 8-channel ADC

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ MCP3008 | 8 | 0-7 | 1350000Hz | 10-bit | 0-1023
 MCP3202 | 2 | 0-1 | 900000Hz | 12-bit | 0-4095
 MCP3204 | 4 | 0-3 | 1000000Hz | 12-bit | 0-4095
 MCP3208 | 8 | 0-7 | 1000000Hz | 12-bit | 0-4095
+MCP3304 | 8 | 0-7 | 2100000Hz | 13-bit | 0-4095
 
 ## API documentation
 
@@ -78,6 +79,7 @@ or undefined.
 - [openMcp3202(channel[, options], cb)](https://github.com/fivdi/mcp-spi-adc#openmcp3202channel-options-cb)
 - [openMcp3204(channel[, options], cb)](https://github.com/fivdi/mcp-spi-adc#openmcp3204channel-options-cb)
 - [openMcp3208(channel[, options], cb)](https://github.com/fivdi/mcp-spi-adc#openmcp3208channel-options-cb)
+- [openMcp3304(channel[, options], cb)](https://github.com/fivdi/mcp-spi-adc#openmcp3304channel-options-cb)
 - [open(channel[, options], cb) - alias for openMcp3008(channel[, options], cb)](https://github.com/fivdi/mcp-spi-adc#openchannel-options-cb---alias-for-openmcp3008channel-options-cb)
 
 ### Class AdcChannel
@@ -91,6 +93,7 @@ or undefined.
 ### openMcp3202(channel[, options], cb)
 ### openMcp3204(channel[, options], cb)
 ### openMcp3208(channel[, options], cb)
+### openMcp3304(channel[, options], cb)
 ### open(channel[, options], cb) - alias for openMcp3008(channel[, options], cb)
 - channel - the number of the channel to open, see channel numbers in
 [supported devices](https://github.com/fivdi/mcp-spi-adc#supported-devices)

--- a/mcp-spi-adc.js
+++ b/mcp-spi-adc.js
@@ -63,6 +63,19 @@ var CONFIG_MCP3202 = Object.freeze({
   }
 });
 
+var CONFIG_MCP3304 = Object.freeze({
+  channelCount: 8,
+  maxRawValue: 4095,
+  defaultSpeedHz: 2100000, // See MCP3304 datasheet. 100000 * 21 = 2100000
+  transferLength: 3,
+  readChannelCommand: function (channel) {
+    return new Buffer([((channel & 6) >> 1) + 12, (channel & 1) << 7, 0x00]);
+  },
+  rawValue: function (buffer) {
+    return ((buffer[1] & 0x0f) << 8) + buffer[2];
+  }
+});
+
 function AdcChannel(config, channel, options, cb) {
   if (!(this instanceof AdcChannel)) {
     return new AdcChannel(config, channel, options, cb);
@@ -140,3 +153,6 @@ module.exports.openMcp3208 = function (channel, options, cb) {
   return new AdcChannel(CONFIG_MCP3208, channel, options, cb);
 };
 
+module.exports.openMcp3304 = function (channel, options, cb) {
+  return new AdcChannel(CONFIG_MCP3304, channel, options, cb);
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-spi-adc",
   "version": "0.3.1",
-  "description": "MCP3002/4/8 and MCP3202/4/8 SPI analog to digital conversion",
+  "description": "MCP3002/4/8, MCP3202/4/8 and MCP3304 SPI analog to digital conversion",
   "main": "mcp-spi-adc.js",
   "directories": {
     "example": "example",
@@ -30,6 +30,7 @@
     "raspberry",
     "spi",
     "adc",
+    "mcp3304",
     "mcp3208",
     "mcp3204",
     "mcp3202",


### PR DESCRIPTION
Adds support for the MCP3304 chip, datasheet here: http://www.microchip.com/wwwproducts/en/MCP3304

This is a 8-channel ADC, similar to MCP3208 and MCP3304, but 13-bit instead of 10- or 12-bit. It also optionally supports differential inputs (using the 4 channel pairs) but this PR only adds 8-channel single-sided input support. Tested on a Raspberry Pi 3.
